### PR TITLE
fix: fonts in styles

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -3,9 +3,6 @@
 body {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
-  font-weight: 400;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
   padding: 10px;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,6 @@
 @import "@penpot/plugin-styles/styles.css";
 
 body {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   padding: 10px;
 }


### PR DESCRIPTION
Currently `Work Sans` from the `@penpot/plugin-styles` is pointless as template's CSS overshadows it completely.

This PR fixes the problem and promotes chosen font to the developer.